### PR TITLE
fix a bug that where(block) doesn't wrap conditions by parenthesis

### DIFF
--- a/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
+++ b/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java
@@ -182,7 +182,7 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
      */
     @SuppressWarnings("unchecked")
     public C where(@NonNull Function1<C, C> block) {
-        return block.apply((C) clone());
+        return where(block.apply(emptyClone()));
     }
 
     @SuppressWarnings("unchecked")
@@ -206,5 +206,14 @@ public abstract class OrmaConditionBase<Model, C extends OrmaConditionBase<Model
         } else {
             return null;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private C emptyClone() {
+        C copied = (C) clone();
+        copied.whereConjunction = " AND ";
+        copied.whereClause = null;
+        copied.bindArgs = null;
+        return copied;
     }
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/QueryTest.java
@@ -79,6 +79,7 @@ public class QueryTest {
                 book.title = "today";
                 book.content = "milk, banana";
                 book.inPrint = true;
+                book.price = 200;
                 book.publisher = SingleAssociation.just(publisher);
                 return book;
             }
@@ -361,6 +362,21 @@ public class QueryTest {
                 .priceGe(100)
                 .toList();
         assertThat(books, hasSize(2));
+    }
+
+    @Test
+    public void whereComplexConditionGroup() throws Exception {
+        List<Book> books = db.selectFromBook()
+                .titleEq("friday")
+                .and()
+                .where(new Function1<Book_Selector, Book_Selector>() {
+                    @Override
+                    public Book_Selector apply(Book_Selector it) {
+                        return it.titleEq("today").or().priceGe(150);
+                    }
+                })
+                .toList();
+        assertThat(books, hasSize(0));
     }
 
     @Test


### PR DESCRIPTION
It's a fix for a bug embedded in #415 .

I use "copy & reset" to obtain the clean condition instance.
Of course I know it's not beautiful but looks little better than [former my code](https://github.com/k-kagurazaka/Android-Orma/blob/a28149e829d5e330685bc7840abc48daf4ae8a66/library/src/main/java/com/github/gfx/android/orma/internal/OrmaConditionBase.java#L185).

I welcome more smart solution.