### PR TITLE
Relax limitation of @Setter constructors to support Kotlin model class with default argument

### DIFF
--- a/library/src/test/java/com/github/gfx/android/orma/test/SetterAndGetterTest.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/SetterAndGetterTest.java
@@ -17,6 +17,7 @@ package com.github.gfx.android.orma.test;
 
 import com.github.gfx.android.orma.ModelFactory;
 import com.github.gfx.android.orma.test.model.ModelWithAccessors;
+import com.github.gfx.android.orma.test.model.ModelWithMultipleSetterConstructors;
 import com.github.gfx.android.orma.test.model.ModelWithNamedSetterConstructor;
 import com.github.gfx.android.orma.test.model.ModelWithSetterConstructor;
 import com.github.gfx.android.orma.test.model.ModelWithSetterConstructorAndNullable;
@@ -123,6 +124,22 @@ public class SetterAndGetterTest {
         assertThat(model.id, is(not(0L)));
         assertThat(model.key, is("key"));
         assertThat(model.value, is(nullValue()));
+    }
+
+    @Test
+    public void testMultipleSetterConstructors() throws Exception {
+        ModelWithMultipleSetterConstructors model = db
+                .createModelWithMultipleSetterConstructors(new ModelFactory<ModelWithMultipleSetterConstructors>() {
+                    @NonNull
+                    @Override
+                    public ModelWithMultipleSetterConstructors call() {
+                        return new ModelWithMultipleSetterConstructors(0, 1, 2);
+                    }
+                });
+
+        assertThat(model.id, is(not(0L)));
+        assertThat(model.foo, is(1));
+        assertThat(model.bar, is(1));
     }
 
 }

--- a/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithMultipleSetterConstructors.java
+++ b/library/src/test/java/com/github/gfx/android/orma/test/model/ModelWithMultipleSetterConstructors.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015 FUJI Goro (gfx).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gfx.android.orma.test.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.PrimaryKey;
+import com.github.gfx.android.orma.annotation.Setter;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ModelWithMultipleSetterConstructors {
+
+    @PrimaryKey
+    public long id;
+
+    @Column
+    public int foo;
+
+    public int bar;
+
+    @Setter
+    public ModelWithMultipleSetterConstructors(long id, int foo, int bar) {
+        this.id = id;
+        this.foo = foo;
+        this.bar = bar;
+    }
+
+    @Setter
+    public ModelWithMultipleSetterConstructors(long id, int foo) {
+        this.id = id;
+        this.foo = foo;
+        this.bar = 1;
+    }
+
+}

--- a/processor/src/test/java/com/github/gfx/android/orma/processor/test/SchemaValidatorTest.java
+++ b/processor/src/test/java/com/github/gfx/android/orma/processor/test/SchemaValidatorTest.java
@@ -89,15 +89,15 @@ public class SchemaValidatorTest {
     }
 
     @Test
-    public void tooManySetterConstructors() throws Exception {
-        JavaFileObject modelFile = JavaFileObjects.forResource("TooManySetterConstructors.java");
+    public void ambiguousSetterConstructors() throws Exception {
+        JavaFileObject modelFile = JavaFileObjects.forResource("AmbiguousSetterConstructors.java");
 
         assert_().about(javaSource())
                 .that(modelFile)
                 .processedWith(new OrmaProcessor())
                 .failsToCompile()
                 .withErrorCount(1)
-                .withErrorContaining("Too many @Setter constructors");
+                .withErrorContaining("Cannot detect a constructor from multiple @Setter constructors that have the same parameter size");
     }
 
     @Test

--- a/processor/src/test/resources/AmbiguousSetterConstructors.java
+++ b/processor/src/test/resources/AmbiguousSetterConstructors.java
@@ -20,21 +20,21 @@ import com.github.gfx.android.orma.annotation.Setter;
 import com.github.gfx.android.orma.annotation.Table;
 
 @Table
-public class TooManySetterConstructors {
+public class AmbiguousSetterConstructors {
 
     @PrimaryKey
     public final String foo;
 
     @Column
-    public final String bar;
+    public final int bar;
 
     @Setter
-    public TooManySetterConstructors() {
-        foo = String.valueOf(System.currentTimeMillis());
-        this.bar = "";
+    public AmbiguousSetterConstructors(String foo, int bar) {
+        this.foo = foo;
+        this.bar = bar;
     }
 
-    public TooManySetterConstructors(@Setter String bar) {
+    public AmbiguousSetterConstructors(@Setter int bar, int baz) {
         foo = String.valueOf(System.currentTimeMillis());
         this.bar = bar;
     }


### PR DESCRIPTION
Related #438 

Currently, Orma requires that `@Setter` annotated constructor should be unique.
However this limitation is not convenient when model classes are written by Kotlin with the primary constructor and default arguments since Kotlin compiler gives `@Setter` annotation to all constructors if the primary constructor has `@JvmOverloads` annotation.

This PR relaxes the limitation. If multiple `@Setter` constructors are found, Orma uses a constructor with arguments of which count is the same as a number of columns.

The modification makes it possible for us to write following code:

```kotlin
@Table
class OrmaTodo @JvmOverloads @Setter constructor(
        @PrimaryKey var id: Long,
        @Column var foo: String,
        var bar: Int? = null
)
```

How about this suggestion?