### PR TITLE
invoke ManualStepMigration at the initial running

### DIFF
--- a/migration/src/main/java/com/github/gfx/android/orma/migration/ManualStepMigration.java
+++ b/migration/src/main/java/com/github/gfx/android/orma/migration/ManualStepMigration.java
@@ -15,10 +15,11 @@
  */
 package com.github.gfx.android.orma.migration;
 
+import com.github.gfx.android.orma.core.Database;
+
 import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
-import com.github.gfx.android.orma.core.Database;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.SparseArray;
@@ -99,11 +100,6 @@ public class ManualStepMigration extends AbstractMigrationEngine {
     @Override
     public void start(@NonNull Database db, @NonNull List<? extends MigrationSchema> schemas) {
         int dbVersion = fetchDbVersion(db);
-
-        if (dbVersion == 0) {
-            db.setVersion(version);
-            return;
-        }
 
         if (dbVersion == version) {
             return;

--- a/migration/src/test/java/com/github/gfx/android/orma/migration/test/ManualStepMigrationTest.java
+++ b/migration/src/test/java/com/github/gfx/android/orma/migration/test/ManualStepMigrationTest.java
@@ -54,7 +54,6 @@ public class ManualStepMigrationTest {
     @Before
     public void setUp() throws Exception {
         db = new DefaultDatabase.Provider().provideOnMemoryDatabase(getContext());
-        db.setVersion(1);
 
         migration = new ManualStepMigration(getContext(), VERSION, true);
 


### PR DESCRIPTION
Fix the behavior that invocations of ManualStepMigration at initial running are skipped. This was an intended behavior, but I think it is users that decide the initial invocation, not the library's authors.

Resolve https://github.com/maskarade/Android-Orma/issues/436

@k-kagurazaka What do you think of it?