### PR TITLE
Replace novoda/bintray-release with bintray/gradle-bintray-plugin

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'com.novoda.bintray-release'
 
 targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -8,15 +7,6 @@ dependencies {
     compileOnly "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
 }
 
-publish {
-    artifactId = 'orma-annotations'
-    desc = 'Annotations for Orma'
-
-    def metadata = project.rootProject.ext.metadata
-    userOrg = metadata.userOrg
-    groupId = metadata.groupId
-    publishVersion = metadata.version
-    website = metadata.website
-    repository = metadata.repository
-    licences = metadata.licences
-}
+archivesBaseName = 'orma-annotations'
+metadata.desc = 'Annotations for Orma'
+apply from: "${project.rootDir}/publish.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.0'
-        classpath 'com.novoda:bintray-release:0.8.1' // https://github.com/novoda/bintray-release
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,7 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion SDK_VERSION
@@ -47,15 +47,6 @@ dependencies {
     api "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
 }
 
-publish {
-    artifactId = 'orma-core'
-    desc = 'The core module for Android-Orma'
-
-    def metadata = rootProject.ext.metadata
-    userOrg = metadata.userOrg
-    groupId = metadata.groupId
-    publishVersion = metadata.version
-    website = metadata.website
-    repository = metadata.repository
-    licences = metadata.licences
-}
+archivesBaseName = 'orma-core'
+metadata.desc = 'The core module for Android-Orma'
+apply from: "${project.rootDir}/publish.gradle"

--- a/encryption/build.gradle
+++ b/encryption/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion SDK_VERSION
@@ -46,15 +46,6 @@ dependencies {
     implementation 'net.zetetic:android-database-sqlcipher:3.5.9'
 }
 
-publish {
-    artifactId = 'orma-encryption'
-    desc = 'Encryption support for Android-Orma'
-
-    def metadata = rootProject.ext.metadata
-    userOrg = metadata.userOrg
-    groupId = metadata.groupId
-    publishVersion = metadata.version
-    website = metadata.website
-    repository = metadata.repository
-    licences = metadata.licences
-}
+archivesBaseName = 'orma-encryption'
+metadata.desc = 'Encryption support for Android-Orma'
+apply from: "${project.rootDir}/publish.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion SDK_VERSION
@@ -74,15 +74,6 @@ dependencies {
     androidTestImplementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
 }
 
-publish {
-    artifactId = 'orma'
-    desc = 'A lightning-fast ORM for Android'
-
-    def metadata = rootProject.ext.metadata
-    userOrg = metadata.userOrg
-    groupId = metadata.groupId
-    publishVersion = metadata.version
-    website = metadata.website
-    repository = metadata.repository
-    licences = metadata.licences
-}
+archivesBaseName = 'orma'
+metadata.desc = 'A lightning-fast ORM for Android'
+apply from: "${project.rootDir}/publish.gradle"

--- a/metadata.gradle
+++ b/metadata.gradle
@@ -4,6 +4,11 @@ ext {
             groupId   : 'com.github.maskarade.android.orma',
             website   : 'https://github.com/maskarade/Android-Orma',
             repository: 'https://github.com/maskarade/Android-Orma.git',
-            licences  : ['Apache-2.0']
+            licences  : ['Apache-2.0'],
+            developer : {
+                id 'gfx'
+                name 'FUJI Goro'
+                email 'gfuji@cpan.org'
+            }
     ]
 }

--- a/migration/build.gradle
+++ b/migration/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion SDK_VERSION
@@ -89,15 +89,6 @@ dependencies {
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
 }
 
-publish {
-    artifactId = 'orma-migration'
-    desc = 'A smart SQLiteDatabase migration engine'
-
-    def metadata = rootProject.ext.metadata
-    userOrg = metadata.userOrg
-    groupId = metadata.groupId
-    publishVersion = metadata.version
-    website = metadata.website
-    repository = metadata.repository
-    licences = metadata.licences
-}
+archivesBaseName = 'orma-migration'
+metadata.desc = 'A smart SQLiteDatabase migration engine'
+apply from: "${project.rootDir}/publish.gradle"

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'com.novoda.bintray-release'
 
 targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -19,15 +18,6 @@ dependencies {
     testImplementation 'com.google.testing.compile:compile-testing:0.10'
 }
 
-publish {
-    artifactId = 'orma-processor'
-    desc = 'An annotation processor for Ormat to generate schema representations'
-
-    def metadata = project.rootProject.ext.metadata
-    userOrg = metadata.userOrg
-    groupId = metadata.groupId
-    publishVersion = metadata.version
-    website = metadata.website
-    repository = metadata.repository
-    licences = metadata.licences
-}
+archivesBaseName = 'orma-processor'
+metadata.desc = 'An annotation processor for Ormat to generate schema representations'
+apply from: "${project.rootDir}/publish.gradle"

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,81 @@
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+
+
+group = metadata.groupId
+version = metadata.version
+
+bintray {
+    //TODO Set appropriate authorize information
+    user = "foo"
+    key = "bar"
+
+    configurations = ['archives']
+    pkg {
+        repo = 'maven'
+        name = archivesBaseName
+        desc = metadata.desc
+        userOrg = metadata.userOrg
+        websiteUrl = metadata.website
+        vcsUrl = metadata.repository
+        licenses = metadata.licences
+    }
+}
+
+task ormaJavadoc(type: Javadoc) {
+    failOnError false
+    options.locale = 'en_US'
+    if (project.hasProperty('android')) {
+        source = android.sourceSets.main.java.sourceFiles
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        classpath += configurations.compile
+    } else {
+        source = sourceSets.main.allJava
+    }
+}
+
+task sourcesJar(type: Jar) {
+    if (project.hasProperty('android')) {
+        from android.sourceSets.main.java.srcDirs
+    } else {
+        from sourceSets.main.allJava
+    }
+    classifier = 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: ormaJavadoc) {
+    from ormaJavadoc.destinationDir
+    classifier = 'javadoc'
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+install {
+    repositories {
+        mavenInstaller {
+            pom.project {
+                packaging 'aar'
+                artifactId archivesBaseName
+                url metadata.website
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer metadata.developer
+                }
+                scm {
+                    connection metadata.repository
+                    developerConnection metadata.repository
+                    url metadata.website
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replace [novoda/bintray-release](https://github.com/novoda/bintray-release) with bintray official [bintray/gradle-bintray-plugin](https://github.com/bintray/gradle-bintray-plugin) to get rid of blocker of #448.

I can't test upload because I don't know the credentials, but you can check generated artifacts and pom.

Execute
```
./gradlew clean install
```
And please verify the files at `$HOME/.m2/repository/com/github/maskarade/android/orma` uploaded to bintray. 