### PR TITLE
migration to Robolectric 4.0; goodbye Robolectric-Instrumentation!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -55,7 +55,8 @@ dependencies {
 
     testAnnotationProcessor project(':processor')
     testImplementation project(':encryption')
-    testImplementation 'com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation:3.1.4'
+    testImplementation "org.robolectric:robolectric:4.0"
+    testImplementation 'androidx.test:runner:1.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'com.google.code.gson:gson:2.8.2'
@@ -65,7 +66,7 @@ dependencies {
 
     androidTestAnnotationProcessor project(':processor')
     androidTestImplementation project(':encryption')
-    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
     androidTestImplementation 'com.google.code.gson:gson:2.8.2'

--- a/migration/build.gradle
+++ b/migration/build.gradle
@@ -34,6 +34,11 @@ android {
     dexOptions {
         preDexLibraries = !System.getenv("CI")
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 final PACKAGE = 'com.github.gfx.android.orma.migration.sqliteparser.g'
@@ -74,17 +79,17 @@ task updateSqliteGrammar(type: Exec) {
     final url = "https://raw.githubusercontent.com/bkiers/sqlite-parser/master/src/main/antlr4/nl/bigo/sqliteparser/SQLite.g4"
     commandLine "curl", "-L", url, "-o", GRAMMAR_FILE
 }
-
 dependencies {
     api project(':core')
     antlr 'org.antlr:antlr4:4.6'
     implementation 'org.antlr:antlr4-runtime:4.6'
     api "androidx.annotation:annotation:${ANDROIDX_ANNOTATION_VERSION}"
 
-    testImplementation 'com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation:3.1.4'
+    testImplementation "org.robolectric:robolectric:4.0"
+    testImplementation 'androidx.test:runner:1.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
-    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
 }


### PR DESCRIPTION
Now robolectric 4.0 has the same functionality as [Robolectric-Instrumentation](https://github.com/maskarade/Robolectric-Instrumentation).